### PR TITLE
Fix error on SetLogLevel and workaround when event already exists

### DIFF
--- a/logmanager/logmanager.go
+++ b/logmanager/logmanager.go
@@ -48,26 +48,22 @@ func init() {
 func SetLogLevel(LogLevel string, exPath string, fileName string, maxSize int, maxBackups int, maxAge int, interactive bool, reportcaller bool, jsontostdout bool) error {
 	log.SetFormatter(&log.JSONFormatter{})
 	level = LogLevel
-
 	switch LogLevel {
 	case "debug":
 		log.SetLevel(log.DebugLevel)
-		break
 	case "info":
 		log.SetLevel(log.InfoLevel)
-		break
 	case "warning":
 		log.SetLevel(log.WarnLevel)
-		break
 	case "error":
 		log.SetLevel(log.ErrorLevel)
-		break
 	case "critical":
 		log.SetLevel(log.FatalLevel)
-		break
 	default:
-		return fmt.Errorf("ezb_lib/logmanager/SetLogLevel() failed: Bad log level name")
+		fmt.Errorf("ezb_lib/logmanager/SetLogLevel() failed: Bad log level name, set to Info")
+		log.SetLevel(log.InfoLevel)
 	}
+
 	// Adding the method and line caller, easier to debug
 	log.SetReportCaller(reportcaller)
 	abspathfilename := exPath+string(os.PathSeparator)+fileName
@@ -80,12 +76,13 @@ func SetLogLevel(LogLevel string, exPath string, fileName string, maxSize int, m
 	}
 
 	if jsontostdout {
-	mWriter := io.MultiWriter(os.Stderr, lj)
+		mWriter := io.MultiWriter(os.Stderr, lj)
 		log.SetOutput(mWriter)
 	} else {
 		log.SetOutput(lj)
 	}
 	log.Info("Log system initialized.")
+
 	return nil
 
 }

--- a/logmanager/logmanager.go
+++ b/logmanager/logmanager.go
@@ -18,19 +18,13 @@ package logmanager
 
 import (
 	"fmt"
-<<<<<<< HEAD
-	"path"
-	"runtime"
-	"strings"
-
-=======
 	"io"
 	"os"
 	"path"
 	"runtime"
 	"strings"
+
 	ezbevent "github.com/ezbastion/ezb_lib/eventlogmanager"
->>>>>>> 6a5ce0a8749038afa3ec71a0628dbc7e36664633
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -42,10 +36,6 @@ type callInfo struct {
 	line        int
 }
 
-<<<<<<< HEAD
-// SetLogLevel set logrus level
-func SetLogLevel(LogLevel string, exPath string, fileName string, maxSize int, maxBackups int, maxAge int) error {
-=======
 // EventLog management
 var eid int
 var osspecific bool
@@ -57,7 +47,6 @@ func init() {
 
 // SetLogLevel set logrus level
 func SetLogLevel(LogLevel string, exPath string, fileName string, maxSize int, maxBackups int, maxAge int, interactive bool, reportcaller bool, jsontostdout bool) error {
->>>>>>> 6a5ce0a8749038afa3ec71a0628dbc7e36664633
 	log.SetFormatter(&log.JSONFormatter{})
 	level = LogLevel
 	switch LogLevel {
@@ -75,21 +64,10 @@ func SetLogLevel(LogLevel string, exPath string, fileName string, maxSize int, m
 		fmt.Errorf("ezb_lib/logmanager/SetLogLevel() failed: Bad log level name, set to Info")
 		log.SetLevel(log.InfoLevel)
 	}
-<<<<<<< HEAD
 
-=======
-<<<<<<< HEAD
-	log.SetOutput(&lumberjack.Logger{
-		Filename:   fileName,
-		MaxSize:    maxSize,
-		MaxBackups: maxBackups,
-		MaxAge:     maxAge,
-	})
-=======
->>>>>>> ed80331f483d63fe1c88c97955fe922e79193bb1
 	// Adding the method and line caller, easier to debug
 	log.SetReportCaller(reportcaller)
-	abspathfilename := exPath+string(os.PathSeparator)+fileName
+	abspathfilename := exPath + string(os.PathSeparator) + fileName
 
 	lj := &lumberjack.Logger{
 		Filename:   abspathfilename,
@@ -133,14 +111,14 @@ func retrieveCallInfo() *callInfo {
 	}
 }
 
-func WithFields(s1 string,s2 string) {
-	log.WithFields(log.Fields{s1:s2})
+func WithFields(s1 string, s2 string) {
+	log.WithFields(log.Fields{s1: s2})
 }
 
 func StartWindowsEvent(name string) {
 	if osspecific == true {
 		if ezbevent.Status == 0 {
-				ezbevent.Open(name)
+			ezbevent.Open(name)
 		}
 	}
 }
@@ -189,7 +167,6 @@ func Error(logline string) error {
 			}
 		}
 	}
->>>>>>> 6a5ce0a8749038afa3ec71a0628dbc7e36664633
 	return nil
 }
 
@@ -206,32 +183,6 @@ func Warning(logline string) error {
 	return nil
 }
 
-<<<<<<< HEAD
-func retrieveCallInfo() *callInfo {
-	pc, file, line, _ := runtime.Caller(2)
-	_, fileName := path.Split(file)
-	parts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
-	pl := len(parts)
-	packageName := ""
-	funcName := parts[pl-1]
-
-	if parts[pl-2][0] == '(' {
-		funcName = parts[pl-2] + "." + funcName
-		packageName = strings.Join(parts[0:pl-2], ".")
-	} else {
-		packageName = strings.Join(parts[0:pl-1], ".")
-	}
-
-	return &callInfo{
-		packageName: packageName,
-		fileName:    fileName,
-		funcName:    funcName,
-		line:        line,
-	}
-}
-=======
 func Fatal(logline string) {
 	log.Fatal(logline)
 }
-
->>>>>>> 6a5ce0a8749038afa3ec71a0628dbc7e36664633

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -157,6 +158,10 @@ func InstallService(name, desc string) error {
 	defer s.Close()
 	err = eventlog.InstallAsEventCreate(name, eventlog.Error|eventlog.Warning|eventlog.Info)
 	if err != nil {
+		if strings.Contains(err.Error(), "ezb_vault registry key already exists") {
+			log.Warnln("Event registry key already exists, skipping warn and continue")
+			return nil
+		}
 		s.Delete()
 		errormsg = fmt.Sprintf("SetupEventLogSource() failed: %s", err)
 		log.Errorln(errormsg)


### PR DESCRIPTION
On SetLogLevel, an issue cause a trouble in the display (output shown but not requested) so the function is fixed. I also try a workaround when the event is already created to not create an error but only log a warning